### PR TITLE
accept 'null' value for 'adresse', 'ville' and 'cp' in raw data

### DIFF
--- a/tests/utils/convert.test.js
+++ b/tests/utils/convert.test.js
@@ -54,5 +54,17 @@ describe('convert features', () => {
                 expect(stationObjectList[i].coordinates.longitude).toEqual(stationRawObjectList[i].geom.lon);
             };
         });
+
+        test('a \'null\' value for \'adresse\', \'ville\' or \'cp\' should not throw', () => {
+            let stationRawObjectListWithNullValues = JSON.parse(JSON.stringify(stationRawObjectList));
+            stationRawObjectListWithNullValues[0].address = null;
+            stationRawObjectListWithNullValues[0].ville = null;
+            stationRawObjectListWithNullValues[0].cp = null;
+            const stationObjectListWithNullValues = convertStationsFormat(stationRawObjectListWithNullValues);
+            stationObjectListWithNullValues.forEach(async (stationObject) => {
+                const doc = Station.hydrate(stationObject);
+                await expect(doc.validate()).resolves.toBeUndefined();
+            });
+        });
     });
 });

--- a/utils/validate.js
+++ b/utils/validate.js
@@ -17,9 +17,9 @@ function validateStationRaw(jsonData) {
             lon: Joi.number().required(),
         }),
 
-        adresse: Joi.string().required(),
+        adresse: Joi.string().allow(null).required(),
         ville: Joi.string().allow(null).required(),
-        cp: Joi.string().required(),
+        cp: Joi.string().allow(null).required(),
 
         gazole_maj: Joi.string().allow(null).required(),
         gazole_prix: Joi.string().allow(null).required(),


### PR DESCRIPTION
FIX "Validation error on raw station object: \"adresse\" must be a string"